### PR TITLE
🔨 Replace unwrap() calls with Result handling

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -385,6 +385,18 @@ impl From<reqwest::Error> for OctokitError {
     }
 }
 
+impl From<hex::FromHexError> for OctokitError {
+    fn from(err: hex::FromHexError) -> Self {
+        OctokitError::new(err.description())
+    }
+}
+
+impl From<openssl::error::ErrorStack> for OctokitError {
+    fn from(err: openssl::error::ErrorStack) -> Self {
+        OctokitError::new(err.description())
+    }
+}
+
 fn perform_get(
     token: &String,
     url: URI,

--- a/src/webhooks.rs
+++ b/src/webhooks.rs
@@ -1,3 +1,4 @@
+use super::OctokitError;
 use openssl::hash::MessageDigest;
 use openssl::memcmp;
 use openssl::sign::Signer;
@@ -5,40 +6,45 @@ use openssl::sign::Signer;
 pub const EVENT_HEADER_NAME: &str = "X-GITHUB-EVENT";
 pub const SIGNATURE_HEADER_NAME: &str = "X-HUB-SIGNATURE";
 
-///  Example signature header
-///  "x-hub-signature": "sha1=4b4a1c9a70dc40caf22099fb2d62a283dedd4614"
 pub fn verify_payload_signature(
     signature: &Option<String>,
     secret: &String,
     body: &String,
 ) -> bool {
+    match signature {
+        None => false,
+        Some(sig) => {
+            let result = verify(&sig, &secret, &body);
+            match result {
+                Ok(validity) => {
+                    println!("signature verification resulted in: {}", validity);
+                    validity
+                }
+                Err(err) => {
+                    println!("payload verification failed with: {}", err);
+                    false
+                }
+            }
+        }
+    }
+}
+
+///  Example signature header
+///  "x-hub-signature": "sha1=4b4a1c9a70dc40caf22099fb2d62a283dedd4614"
+fn verify(signature: &String, secret: &String, body: &String) -> Result<bool, OctokitError> {
     let secret = secret.as_bytes();
     let body = body.as_bytes();
 
-    match signature {
-        Some(sig) => {
-            // discard the 'sha1='-prefix
-            let sighex = &sig[5..];
-            // decode sha1 has hex bytes
-            let sigbytes = hex::decode(sighex).expect("Decoding failed");
+    // discard the 'sha1='-prefix
+    let sighex = &signature[5..];
+    // decode sha1 has hex bytes
+    let sigbytes = hex::decode(sighex)?;
+    // Create a PKey
+    let key = openssl::pkey::PKey::hmac(secret)?;
+    // Compute the HMAC
+    let mut signer = Signer::new(MessageDigest::sha1(), &key)?;
+    signer.update(body)?;
+    let hmac = signer.sign_to_vec()?;
 
-            // Create a PKey
-            let key = openssl::pkey::PKey::hmac(secret).unwrap();
-
-            // Compute the HMAC
-            let mut signer = Signer::new(MessageDigest::sha1(), &key).unwrap();
-            signer.update(body).unwrap();
-            let hmac = signer.sign_to_vec().unwrap();
-
-            println!("signature: sha1={:?}", sighex);
-            println!("bytes: {:?}", sigbytes);
-            println!("hmac is: {:?}", hmac);
-            //            println!("hmac len: {}, sig len: {}", hmac.len(), sigbytes.len());
-
-            let valid = memcmp::eq(&hmac, &sigbytes);
-            println!("validity is: {:?}", valid);
-            valid
-        }
-        None => false,
-    }
+    Ok(memcmp::eq(&hmac, &sigbytes))
 }


### PR DESCRIPTION
Instead of calling `unwrap` on allmost every line, we now convert all
errors to OctokitErrors and handle them gracefully by returning a
boolean and printing errors.

From previous discussions, my actual preference would be:
```rust
let outcome = openssl::pkey::PKey::hmac(secret)
    .and_then(|key| Signer::new(MessageDigest::sha1(), &key))
    .and_then(|mut signer| signer.update(body).map(|_| signer))
    .and_then(|signer: Signer| signer.sign_to_vec())
    .and_then(|hmac| Ok(memcmp::eq(&hmac, &sigbytes)))
    .unwrap_or(false);
    // TODO add logging of the error before converting it to false
    println!("new outcome: {:?}", outcome);
```
but this causes lifetime issues because `key` is passed as a ref to `Signer::new` which is passed to the next and_then.

For comparison, the current implementation (which is much longer) looks like this: 
```rust
pub fn verify_payload_signature(
    signature: &Option<String>,
    secret: &String,
    body: &String,
) -> bool {
    match signature {
        None => false,
        Some(sig) => {
            let result = verify(&sig, &secret, &body);
            match result {
                Ok(valid) => {
                    println!("signature verification resulted in: {}", valid);
                    valid
                }
                Err(err) => {
                    println!("payload verification failed with: {}", err);
                    false
                }
            }
        }
    }
}

///  Example signature header
///  "x-hub-signature": "sha1=4b4a1c9a70dc40caf22099fb2d62a283dedd4614"
fn verify(signature: &String, secret: &String, body: &String) -> Result<bool, OctokitError> {
    let secret = secret.as_bytes();
    let body = body.as_bytes();

    // discard the 'sha1='-prefix
    let sighex = &signature[5..];
    // decode sha1 has hex bytes
    let sigbytes = hex::decode(sighex)?;
    // Create a PKey
    let key = openssl::pkey::PKey::hmac(secret)?;
    // Compute the HMAC
    let mut signer = Signer::new(MessageDigest::sha1(), &key)?;
    signer.update(body)?;
    let hmac = signer.sign_to_vec()?;

    Ok(memcmp::eq(&hmac, &sigbytes))
}
```
Especially the nested match and the noise in the outer function reads kind of annoying. The inner and private function looks good to me.